### PR TITLE
refactor: rename Error schema to ErrorResponse

### DIFF
--- a/src/spec/openapi/openapi.ts
+++ b/src/spec/openapi/openapi.ts
@@ -166,16 +166,16 @@ export function openapiFromHandlers(handlers: Record<string, unknown>, options: 
         components: {
             ...options.components,
             schemas: {
-                Error: defaultError,
+                ErrorResponse: defaultError,
             },
             requestBodies: {},
             responses: {
-                Error: {
+                ErrorResponse: {
                     description: errorDescription,
                     content: {
                         'application/json': {
                             schema: {
-                                $ref: '#/components/schemas/Error',
+                                $ref: '#/components/schemas/ErrorResponse',
                             },
                         },
                     },


### PR DESCRIPTION
This pull request renames the "Error" schema and response to "ErrorResponse" in the OpenAPI specification. The changes ensure consistency in naming conventions and improve clarity in the API documentation. The $ref to the error schema has been updated accordingly.